### PR TITLE
Include semantic and mood colors in module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-module.exports = {
+let colors = {
   normal: {
     black: '#3C4C55',
     red: '#DF8C8C',
@@ -19,5 +19,28 @@ module.exports = {
     dark: '#1E272C',
     medium: '#556873',
     light: '#6A7D89',
-  },
+  }
+};
+
+colors.semantic = {
+  valueOrState: colors.normal.cyan,
+  identifier: colors.normal.blue,
+  global: colors.normal.magenta,
+  emphasis: colors.bright.magenta,
+  actionNeeded: colors.normal.red,
+  special: colors.bright.red,
+  statement: colors.normal.yellow,
+  type: colors.normal.green,
+
+  trivial: colors.bright.black,
+  background: '#435661',
+  foreground: colors.normal.white
+};
+
+colors.mood = {
+  positive: colors.normal.green,
+  negative: colors.normal.red,
+  neutral: colors.normal.blue
 }
+
+module.exports = colors;


### PR DESCRIPTION
Fixes #20 

---

Some comments:

- I couldn't figure out how to get default exports to work, I kept running into this (node 6.3.1):

  ```
  /home/daniel/dev/Tyriar/nova-colors/index.js:1                                                                                                                                   
  (function (exports, require, module, __filename, __dirname) { export default 'abc';                                                                                              
                                                                ^^^^^^                                                                                                             
  SyntaxError: Unexpected token export
  ```

- Not sure if `mood` is the best work for positive/negative/neutral
- I used the background color from the screenshot which doesn't seem to be anywhere in `normal`, `bright` or `decoration`